### PR TITLE
Return result of original function

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ export function reduxify(store) {
           // this action will be used for logging
           store[prop] = function () {
             lastAction = (dispatched ? "dispatched " : "") + prop;
-            fn.apply(store, arguments);
+            return fn.apply(store, arguments);
           };;
         }
       }


### PR DESCRIPTION
Sorry for not creating an issue first. This was a really simple fix. I do not know if this is a bug or a feature but personally, I spent a lot of time debugging why my function always returned `undefined`.

This PR makes the function return the original return value.