### PR TITLE
Disable reduxify on server

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,10 @@ function get(store) {
 
 function connectToDevTools() {
   // connect to redux devtools
-  var devTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__.connect();
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  var devTools = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__.connect();
   if (!devTools) {
     console.info("Could not connect to redux devtools");
   }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function get(store) {
 
 function connectToDevTools() {
   // connect to redux devtools
-  var devTools = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__.connect();
+  var devTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__.connect();
   if (!devTools) {
     console.info("Could not connect to redux devtools");
   }


### PR DESCRIPTION
Currently this throws errors when the code runs on the server in sveltekit. This simply checks whether `window` exists before starting and returns the unwrapped store if not running in a browser